### PR TITLE
[#IC-470] [FIX] build `rptId` using payee fiscalcode in GetMessages (fallback)

### DIFF
--- a/GetMessages/getMessagesFunctions/getMessages.view.ts
+++ b/GetMessages/getMessagesFunctions/getMessages.view.ts
@@ -20,6 +20,7 @@ import * as AI from "../../utils/AsyncIterableTask";
 
 import { MessageViewExtendedQueryModel } from "../../model/message_view_query";
 import { TagEnum } from "../../generated/backend/MessageCategoryBase";
+import { TagEnum as TagEnumPayment } from "../../generated/backend/MessageCategoryPayment";
 import { EnrichedMessageWithContent, InternalMessageCategory } from "./models";
 import { IGetMessagesFunction, IPageResult } from "./getMessages.selector";
 
@@ -112,6 +113,6 @@ const toCategory = (itemComponents: Components): InternalMessageCategory =>
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         noticeNumber: itemComponents.payment.notice_number as NonEmptyString,
-        tag: "PAYMENT"
+        tag: TagEnumPayment.PAYMENT
       }
     : { tag: TagEnum.GENERIC };

--- a/GetMessages/getMessagesFunctions/models.ts
+++ b/GetMessages/getMessagesFunctions/models.ts
@@ -2,10 +2,15 @@
 import * as t from "io-ts";
 
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
-import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import {
+  FiscalCode,
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
 import { DateFromTimestamp } from "@pagopa/ts-commons/lib/dates";
-import { withDefault } from "@pagopa/ts-commons/lib/types";
+import { enumType, withDefault } from "@pagopa/ts-commons/lib/types";
 
+import { TagEnum as TagEnumPayment } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageCategoryPayment";
 import { MessageCategoryBase } from "@pagopa/io-functions-commons/dist/generated/definitions/MessageCategoryBase";
 import { TimeToLiveSeconds } from "../../generated/backend/TimeToLiveSeconds";
 
@@ -13,10 +18,15 @@ import { TimeToLiveSeconds } from "../../generated/backend/TimeToLiveSeconds";
 // ---------------------------------------
 
 export const InternalMessageCategoryPayment = t.exact(
-  t.interface({
-    tag: t.literal("PAYMENT"),
-    noticeNumber: NonEmptyString
-  }),
+  t.intersection([
+    t.interface({
+      tag: enumType<TagEnumPayment>(TagEnumPayment, "tag"),
+      noticeNumber: NonEmptyString
+    }),
+    t.partial({
+      payeeFiscalCode: OrganizationFiscalCode
+    })
+  ]),
   "MessageCategoryPayment"
 );
 

--- a/__mocks__/mocks.service_preference.ts
+++ b/__mocks__/mocks.service_preference.ts
@@ -46,7 +46,8 @@ export const aRetrievedService: RetrievedService = ({
   serviceId: aServiceId,
   isVisible: true,
   serviceName: "a Service",
-  organizationName: "a Organization"
+  organizationName: "a Organization",
+  organizationFiscalCode: "99999999999"
 } as any) as RetrievedService;
 
 export const anActiveActivation: Activation = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- use payee fiscal code for building rptId, if it's defined, service fiscal code otherwise

NOTE: another PR is necessary to refactor getMessage.view implementation.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Payment messages `rptId` are now built using service fiscal code when returning the inbox list. 
This is not correct, since `rptId` should be construct using payee fiscal code, when this value is defined.

NOTE: This is not causing any bugs since the app is not actively using this value yet.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
