### PR TITLE
[#IOCOM-195] Replace custom healthcheck with the one in docker compose

### DIFF
--- a/__integrations__/__tests__/getMessage.test.ts
+++ b/__integrations__/__tests__/getMessage.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable sort-keys */
-import { exit } from "process";
 
 import { CosmosClient, Database } from "@azure/cosmos";
 import { createBlobService } from "azure-storage";
@@ -26,11 +25,9 @@ import { aService, serviceList } from "../__mocks__/mock.services";
 import { createBlobs } from "../__mocks__/utils/azure_storage";
 import { getNodeFetch } from "../utils/fetch";
 import { getMessage } from "../utils/client";
-import { log } from "../utils/logger";
 
 import {
   WAIT_MS,
-  SHOW_LOGS,
   COSMOSDB_URI,
   COSMOSDB_KEY,
   COSMOSDB_NAME,
@@ -74,7 +71,7 @@ beforeAll(async () => {
         },
         O.none
       ),
-      TE.getOrElse(e => {
+      TE.getOrElse(_ => {
         throw Error("Cannot create db");
       })
     )()
@@ -91,8 +88,6 @@ beforeAll(async () => {
   await fillMessagesStatus(database, messageStatusList);
   await fillMessagesView(database, messagesList, messageStatusList);
   await fillServices(database, serviceList);
-
-  await waitFunctionToSetup();
 });
 
 beforeEach(() => {
@@ -155,31 +150,3 @@ describe("Get Message |> Success Results", () => {
     expect(body).toEqual(expected);
   });
 });
-
-// -----------------------
-// utils
-// -----------------------
-
-const delay = (ms: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, ms));
-
-const waitFunctionToSetup = async (): Promise<void> => {
-  log("ENV: ", COSMOSDB_URI, WAIT_MS, SHOW_LOGS);
-  // eslint-disable-next-line functional/no-let
-  let i = 0;
-  while (i < MAX_ATTEMPT) {
-    log("Waiting the function to setup..");
-    try {
-      await fetch(baseUrl + "/api/info");
-      break;
-    } catch (e) {
-      log("Waiting the function to setup..");
-      await delay(WAIT_MS);
-      i++;
-    }
-  }
-  if (i >= MAX_ATTEMPT) {
-    log("Function unable to setup in time");
-    exit(1);
-  }
-};

--- a/__integrations__/__tests__/getMessages.test.ts
+++ b/__integrations__/__tests__/getMessages.test.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable sort-keys */
-import { exit } from "process";
-
 import { CosmosClient, Database } from "@azure/cosmos";
 import { createBlobService } from "azure-storage";
 
@@ -40,11 +38,9 @@ import {
 import { createBlobs } from "../__mocks__/utils/azure_storage";
 import { getNodeFetch } from "../utils/fetch";
 import { getMessages, getMessagesWithEnrichment } from "../utils/client";
-import { log } from "../utils/logger";
 
 import {
   WAIT_MS,
-  SHOW_LOGS,
   COSMOSDB_URI,
   REMOTE_CONTENT_COSMOSDB_URI,
   REMOTE_CONTENT_COSMOSDB_KEY,
@@ -114,8 +110,6 @@ beforeAll(async () => {
   await fillMessagesView(cosmosdb, messagesList, messageStatusList);
   await fillServices(cosmosdb, serviceList);
   await fillRemoteContent(rccosmosdb, aRemoteContentConfigurationList);
-
-  await waitFunctionToSetup();
 });
 
 beforeEach(() => {
@@ -230,31 +224,3 @@ describe("Get Messages |> Success Results, With Enrichment", () => {
     expect(body.items[0].has_precondition).toBeTruthy();
   });
 });
-
-// -----------------------
-// utils
-// -----------------------
-
-const delay = (ms: number): Promise<void> =>
-  new Promise(resolve => setTimeout(resolve, ms));
-
-const waitFunctionToSetup = async (): Promise<void> => {
-  log("ENV: ", COSMOSDB_URI, REMOTE_CONTENT_COSMOSDB_URI, WAIT_MS, SHOW_LOGS);
-  // eslint-disable-next-line functional/no-let
-  let i = 0;
-  while (i < MAX_ATTEMPT) {
-    log("Waiting the function to setup..");
-    try {
-      await fetch(baseUrl + "/api/info");
-      break;
-    } catch (e) {
-      log("Waiting the function to setup..");
-      await delay(WAIT_MS);
-      i++;
-    }
-  }
-  if (i >= MAX_ATTEMPT) {
-    log("Function unable to setup in time");
-    exit(1);
-  }
-};

--- a/__integrations__/docker-compose.yml
+++ b/__integrations__/docker-compose.yml
@@ -57,6 +57,11 @@ services:
     build:
       context: ..
       dockerfile: ./docker/functions/Dockerfile
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7071/api/v1/ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
     ports:
       - ${FUNCTION_PORT}:7071
     links:
@@ -77,8 +82,13 @@ services:
       - "./:/usr/src/app"
       - "../openapi:/usr/src/openapi"
     depends_on:
-      - cosmosdb
-      - cosmosdbrc
-      - storage-account
+      function:
+        condition: service_healthy
+      cosmosdb:
+        condition: service_started
+      cosmosdbrc:
+        condition: service_started
+      storage-account:
+        condition: service_started
     links:
       - function


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

* Remove the custom `healthcheck` inside test suites;
* Add the `healthcheck` for the function in `docker-compose`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We no longer need to use a custom `healthcheck` since there is the possibility to use the [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck) in `docker-compose.yaml`

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Integration testt

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
