### PR TITLE
[#IOCOM-1031] Fixed return type to be compliant to specs

### DIFF
--- a/GetRCConfiguration/__tests__/handler.test.ts
+++ b/GetRCConfiguration/__tests__/handler.test.ts
@@ -6,7 +6,7 @@ import * as TE from "fp-ts/lib/TaskEither";
 import { context as contextMock } from "../../__mocks__/context";
 import { GetRCConfigurationHandler } from "../handler";
 import * as rCConfigurationUtils from "../../utils/remoteContentConfig";
-import { aRetrievedRemoteContentConfigurationWithBothEnv, mockConfig, mockRCConfigurationModel } from "../../__mocks__/remote-content";
+import { aRemoteContentConfigurationWithBothEnv, aRetrievedRemoteContentConfigurationWithBothEnv, mockConfig, mockRCConfigurationModel } from "../../__mocks__/remote-content";
 
 const getOrCacheMaybeRCConfigurationMock = jest
   .fn()
@@ -66,7 +66,7 @@ describe("GetRCConfigurationHandler", () => {
 
     expect(result.kind).toBe("IResponseSuccessJson");
     if (result.kind === "IResponseSuccessJson") {
-      expect(result.value).toEqual(aRetrievedRemoteContentConfigurationWithBothEnv);
+      expect(result.value).toEqual(aRemoteContentConfigurationWithBothEnv);
     }
   });
 });

--- a/GetRCConfiguration/handler.ts
+++ b/GetRCConfiguration/handler.ts
@@ -22,15 +22,14 @@ import {
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { RedisClient } from "redis";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
-import {
-  RCConfiguration,
-  RCConfigurationModel
-} from "@pagopa/io-functions-commons/dist/src/models/rc_configuration";
+import { RCConfigurationModel } from "@pagopa/io-functions-commons/dist/src/models/rc_configuration";
+import { retrievedRCConfigurationToPublic } from "@pagopa/io-functions-commons/dist/src/utils/rc_configuration";
 import { Context } from "@azure/functions";
 import { getOrCacheMaybeRCConfiguration } from "../utils/remoteContentConfig";
+import { RCConfigurationPublic } from "../generated/definitions/RCConfigurationPublic";
 
 type IGetRCConfigurationHandlerResponse =
-  | IResponseSuccessJson<RCConfiguration>
+  | IResponseSuccessJson<RCConfigurationPublic>
   | IResponseErrorNotFound
   | IResponseErrorInternal;
 
@@ -73,6 +72,7 @@ export const GetRCConfigurationHandler = (
         )
       )
     ),
+    TE.map(retrievedRCConfigurationToPublic),
     TE.map(ResponseSuccessJson),
     TE.toUnion
   )();

--- a/__mocks__/remote-content.ts
+++ b/__mocks__/remote-content.ts
@@ -13,6 +13,7 @@ import { IConfig } from "../utils/config";
 import { RCConfigurationBase } from "../generated/definitions/RCConfigurationBase"
 import { RCConfigurationPublic } from "../generated/definitions/RCConfigurationPublic"
 import { RCConfiguration, RetrievedRCConfiguration } from "@pagopa/io-functions-commons/dist/src/models/rc_configuration";
+import { RCConfigurationProdEnvironment } from "../generated/definitions/RCConfigurationProdEnvironment";
 
 export const mockFind = jest.fn(() =>
   TE.of(O.some(aRetrievedRemoteContentConfiguration))
@@ -71,12 +72,12 @@ const aRemoteContentConfigurationWithNoEnv: RCConfigurationBase = {
   is_lollipop_enabled: false
 };
 
-const aRemoteContentConfigurationWithProdEnv: RCConfigurationPublic = {
+export const aRemoteContentConfigurationWithProdEnv: RCConfigurationPublic = {
   ...aRemoteContentConfigurationWithNoEnv,
   prod_environment: aRemoteContentEnvironmentConfiguration
 };
 
-const aRemoteContentConfigurationWithBothEnv: RCConfigurationPublic = {
+export const aRemoteContentConfigurationWithBothEnv: RCConfigurationPublic = {
   ...aRemoteContentConfigurationWithNoEnv,
   prod_environment: aRemoteContentEnvironmentConfiguration,
   test_environment: {
@@ -120,4 +121,3 @@ export const aRetrievedRemoteContentConfigurationWithBothEnv: RetrievedRCConfigu
   _self: "_self",
   _ts: 1
 };
-


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
GetRCConfiguration was returning a result with the old camelCased type. OPENAPI specs where designed to return the RCConfigurationPublic that is snake_cased.

#### Motivation and Context
Bugfix.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
